### PR TITLE
fix: 修复上传多个空文件情况下，文件上传不成功的问题 (#1)

### DIFF
--- a/copy.js
+++ b/copy.js
@@ -8,7 +8,8 @@ module.exports = function(options) {
   const total = currentFilesInfo.length;
   const size = currentFilesInfo.reduce((preVal, cVal) => preVal + cVal.size, 0);
   const spinner = ora("开始传输文件... \n").start();
-  let currentSize = 0
+  let currentSize = 0;
+  let hasPublishedFile = 0;
 
   ora().info(`总共 ${total} 个文件, 大小总计 ${size} 字节 需要传输 ... \n`);
 
@@ -28,11 +29,12 @@ module.exports = function(options) {
       return sftp.mkdir(absRemotePath, true);
     } else {
       sftp.fastPut(absLocalPath, absRemotePath).then(() => {
+        hasPublishedFile++;
         currentSize += info.size
         spinner.text = `传输: ${((currentSize * 100) / size).toFixed(
           2
         )}% ${absRemotePath} ${info.size} 字节`;
-        if (currentSize === size) {
+        if (hasPublishedFile === total) {
           spinner.succeed("传输: 100%");
           sftp.end();
         }


### PR DESCRIPTION
【场景】

有如下场景：
有两个文件分别为  `/test/a.txt` 和 `/test/other/b.txt`，两个文件里面无内容

【现象】

实际只有第一个文件上传成功

【原因】

源码中检测上传成功的条件是上传总大小达到文件总大小。但是空文件总大小为零，导致第一个空文件上传后就满足了此检测条件。改成比较文件总数来解决问题。